### PR TITLE
Update serpsbot api to v3

### DIFF
--- a/serpsbot/configuration.py
+++ b/serpsbot/configuration.py
@@ -46,7 +46,7 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
     def __init__(self):
         """Constructor"""
         # Default Base url
-        self.host = "https://api.serpsbot.com/v2"
+        self.host = "https://api.serpsbot.com/v3"
         # Temp file folder for downloading files
         self.temp_folder_path = None
 


### PR DESCRIPTION
I've updated the serpsbot api link to v3. V2 has a sunset set to August 30, 2023.